### PR TITLE
Remove highlighting of user during url-shortening

### DIFF
--- a/plugins/shorten_urls.lua
+++ b/plugins/shorten_urls.lua
@@ -74,8 +74,12 @@ return {
 					end
 				end
 				if #msg > 0 then
-					msg = sender[1] .. ": " .. msg
-					irc:PRIVMSG(origin, msg)
+					-- Prevent the user's client from triggering a notification,
+					-- by including a zero-width space character in their name
+					-- (that character might be invisible in your editor)
+					local nick = sender[1]:gsub("^(.)(.*)$", "%1​%2")
+					msg = nick .. ": " .. msg
+					irc:NOTICE(origin, msg)
 				end
 			end
 		end;


### PR DESCRIPTION
This is completely unnecessary: It will only ping me when I
just sent a URL, and I'll already know I sent a URL, there's
no need to remind me about that.

I also don't need to be reminded of the title,
so this is just annoying.