### PR TITLE
Use unicode escape

### DIFF
--- a/plugins/shorten_urls.lua
+++ b/plugins/shorten_urls.lua
@@ -76,8 +76,7 @@ return {
 				if #msg > 0 then
 					-- Prevent the user's client from triggering a notification,
 					-- by including a zero-width space character in their name
-					-- (that character might be invisible in your editor)
-					local nick = sender[1]:gsub("^(.)(.*)$", "%1​%2")
+					local nick = sender[1]:gsub("^(.)(.*)$", "%1\u{200b}%2")
 					msg = nick .. ": " .. msg
 					irc:NOTICE(origin, msg)
 				end


### PR DESCRIPTION
Then we don't have to worry about inferior editors